### PR TITLE
Adjust for Hapi 17

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,7 +51,7 @@ const init = async function (options) {
 
     plugins.unshift(steerage);
 
-    const server = new Hapi.Server(store.get('server'));
+    const server = Hapi.server(store.get('server'));
 
     await server.register(plugins);
 

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -2,13 +2,6 @@
 
 const Topo = require('topo');
 
-const getPlugin = function (plugin) {
-    return {
-        plugin: plugin.plugin.plugin,
-        options: plugin.options ? plugin.options : {}
-    };
-};
-
 const resolve = function (registrations) {
     const plugins = new Topo();
 
@@ -16,7 +9,8 @@ const resolve = function (registrations) {
         if (plugin.enabled === false) {
             continue;
         }
-        plugins.add([getPlugin(plugin)], { before: plugin.before, after: plugin.after, group: name });
+
+        plugins.add([plugin], { before: plugin.before, after: plugin.after, group: name });
     }
 
     return plugins.nodes;

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Topo = require('topo');
-const Entries = require('entries');
 
 const getPlugin = function (plugin) {
     return {
@@ -13,7 +12,7 @@ const getPlugin = function (plugin) {
 const resolve = function (registrations) {
     const plugins = new Topo();
 
-    for (const [name, plugin] of Entries(registrations)) {
+    for (const [name, plugin] of Object.entries(registrations)) {
         if (plugin.enabled === false) {
             continue;
         }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -3,6 +3,13 @@
 const Topo = require('topo');
 const Entries = require('entries');
 
+const getPlugin = function (plugin) {
+    return {
+        plugin: plugin.plugin.plugin,
+        options: plugin.options ? plugin.options : {}
+    };
+};
+
 const resolve = function (registrations) {
     const plugins = new Topo();
 
@@ -10,8 +17,7 @@ const resolve = function (registrations) {
         if (plugin.enabled === false) {
             continue;
         }
-
-        plugins.add([plugin], { before: plugin.before, after: plugin.after, group: name });
+        plugins.add([getPlugin(plugin)], { before: plugin.before, after: plugin.after, group: name });
     }
 
     return plugins.nodes;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "steerage",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4837,15 +4837,6 @@
         }
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -4865,6 +4856,15 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0",
         "function-bind": "1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "determination": "^2.0.0",
     "dot-prop": "^4.1.1",
-    "entries": "^1.0.1",
     "hoek": "^5.0.2",
     "joi": "^13.0.2",
     "shortstop-handlers": "^1.0.1",

--- a/test/fixtures/devPlugin.js
+++ b/test/fixtures/devPlugin.js
@@ -7,4 +7,4 @@ const plugin = {
     }
 };
 
-module.exports = plugin;
+exports.plugin = plugin;

--- a/test/fixtures/otherPlugin.js
+++ b/test/fixtures/otherPlugin.js
@@ -7,4 +7,4 @@ const plugin = {
     }
 };
 
-module.exports = plugin;
+exports.plugin = plugin;

--- a/test/fixtures/plugin.js
+++ b/test/fixtures/plugin.js
@@ -7,4 +7,4 @@ const plugin = {
     }
 };
 
-module.exports = plugin;
+exports.plugin = plugin;


### PR DESCRIPTION
This will allow for Hapi 17 style plugins to be registered in a manifest.

* remove `entries` in favor of `Object.entries`
* match Hapi 17 plugin format
  * ~adjust plugin resolution code~
  * adjust test fixtures 