### PR TITLE
Breaking: Update hapi to v18 and use @hapi scoped packages

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint:recommended", "eslint-config-hapi"],
+  "extends": ["eslint:recommended", "@hapi/eslint-config-hapi"],
   "parserOptions": {
     "ecmaVersion": 2017,
     "sourceType": "module"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 
+### 8.0.0
+
+- Update to support hapi v18 and to use @hapi scoped packages
+- BREAKING: @hapi/hapi version >= 18.3.1 now required (also note the new "@hapi/" npm scope)
+
 ### 7.0.3
 
 - Update dependencies including allowing for peer dependency Hapi 18.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # steerage
 
-Plugin for configuring and composing [Hapi](http://hapijs.com) (version `>= 17.0.0 < 18.0.0`) servers through a configuration file or manifest.
+Plugin for configuring and composing [Hapi](http://hapijs.com) servers through a configuration file or manifest.
 
 Supports environment-aware configuration and more using [determination](https://github.com/tlivings/determination).
 
 ### Usage
+
+**Please note:** steerage version 8.x now requires hapi v18 - if you are still on hapi v17, please continue to use steerage version 7.x instead.
 
 ```javascript
 const Path = require('path');

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const Handlers = require('shortstop-handlers');
-const Hoek = require('hoek');
+const Hoek = require('@hapi/hoek');
 const Determination = require('determination');
 
 const resolve = async function ({ config, basedir, protocols, environment }) {
+
     const defaultProtocols = {
         file:    Handlers.file(basedir),
         path:    Handlers.path(basedir),

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,9 +4,9 @@ const Pkg = require('../package.json');
 const Plugins = require('./plugins');
 const Config = require('./config');
 const Path = require('path');
-const Joi = require('joi');
+const Joi = require('@hapi/joi');
 const Props = require('dot-prop');
-const Hapi = require('hapi');
+const Hapi = require('@hapi/hapi');
 
 const schema = Joi.object({
     basedir: Joi.string().allow(null),
@@ -17,6 +17,7 @@ const schema = Joi.object({
 }).required();
 
 const init = async function (options) {
+
     const { config, basedir = Path.dirname(config), onconfig, protocols, environment } = await Joi.validate(options, schema);
 
     const resolved = await Config.resolve({ basedir, config, protocols, environment });
@@ -29,6 +30,7 @@ const init = async function (options) {
         version: Pkg.version,
 
         register: function (server) {
+
             const appSettings = store.get('server.app') || {};
 
             Object.defineProperty(server.app, 'config', {
@@ -37,9 +39,11 @@ const init = async function (options) {
                 writeable: false,
                 value: {
                     get(key) {
+
                         return Props.get(appSettings, key);
                     },
                     set(key, value) {
+
                         Props.set(appSettings, key, value);
                     }
                 }

--- a/lib/plugins.js
+++ b/lib/plugins.js
@@ -3,6 +3,7 @@
 const Topo = require('topo');
 
 const resolve = function (registrations) {
+
     const plugins = new Topo();
 
     for (const [name, plugin] of Object.entries(registrations)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "steerage",
   "description": "Hapi plugin for server configuration and composition using confidence, topo, and shortstop.",
-  "version": "7.0.3",
+  "version": "8.0.0",
   "author": "Trevor Livingston <tlivings@gmail.com>",
   "repository": {
     "type": "git",
@@ -12,28 +12,28 @@
     "node": ">= 8.0.0"
   },
   "dependencies": {
+    "@hapi/hoek": "^7.1.0",
+    "@hapi/joi": "^15.0.3",
     "determination": "^2.0.0",
     "dot-prop": "^4.1.1",
-    "hoek": "^6.1.2",
-    "joi": "^14.3.1",
     "shortstop-handlers": "^1.0.1",
     "topo": "^3.0.0"
   },
   "peerDependencies": {
-    "hapi": ">=17.0.0"
+    "@hapi/hapi": ">=18.3.1"
   },
   "devDependencies": {
+    "@hapi/eslint-config-hapi": "^12.1.0",
+    "@hapi/eslint-plugin-hapi": "^4.3.3",
+    "@hapi/hapi": "^18.3.1",
     "eslint": "^5.15.1",
-    "eslint-config-hapi": "^12.0.0",
-    "eslint-plugin-hapi": "^4.0.0",
-    "hapi": "^18.1.0",
     "nyc": "^13.3.0",
     "tape": "^4.2.2"
   },
   "scripts": {
     "cover": "nyc npm test",
     "lint": "eslint lib",
-    "test": "tape test/*.js"
+    "test": "npm run lint && tape test/*.js"
   },
   "main": "./lib",
   "license": "MIT"

--- a/test/test-steerage.js
+++ b/test/test-steerage.js
@@ -3,7 +3,6 @@
 const Test = require('tape');
 const Steerage = require('../lib');
 const Path = require('path');
-const Hapi = require('hapi');
 
 Test('configures', async function (t) {
     t.plan(7);


### PR DESCRIPTION
Update Hapi to v18 - I went through all the breaking changes at https://github.com/hapijs/hapi/issues/3871 and did not spot any potential issues. 

`npm run test` passed successfully on both Node v8 and v10